### PR TITLE
[Users] Fix: Default new account locale

### DIFF
--- a/ekranoplan/users/core.py
+++ b/ekranoplan/users/core.py
@@ -72,7 +72,7 @@ class CoreUsers(Controller):
         password = await get_hash(str(data.pop('password')))
         flags = 1 << 0
         bio = str(data.get('bio') or '')
-        locale = str(data.get('locale') or 'en_US')
+        locale = str(data.get('locale') or 'en-US')
         referrer = request.query.get('utm_source') or ''
         pronouns = str(data.get('pronouns') or '')
         pfp_id = ''


### PR DESCRIPTION
Valid Locales are defined [here](https://github.com/concordchat/api/blob/canary/ekranoplan/utils.py#L33-L36) with dash separators instead of underscores.

But, while making a new account, if locale is not passed in- it defaults to `en_US` with an underscore- which fails the locale check [here](https://github.com/concordchat/api/blob/canary/ekranoplan/users/core.py#L87)

This fixes users to make new accounts without passing in locale- with a single character change!